### PR TITLE
Change from Log to LogError when reporting a python error

### DIFF
--- a/Soomla/Assets/Soomla/Editor/SoomlaPostBuild.cs
+++ b/Soomla/Assets/Soomla/Editor/SoomlaPostBuild.cs
@@ -40,8 +40,8 @@ public class PostProcessScriptStarter : MonoBehaviour {
 			proc.WaitForExit();
 //			UnityEngine.Debug.Log("out: " + output);
 			if (proc.ExitCode != 0) {
-				UnityEngine.Debug.Log("error: " + err + "   code: " + proc.ExitCode);
-			}
+                UnityEngine.Debug.LogError("error: " + err + "   code: " + proc.ExitCode);
+            }
 		}
 #endif
     }


### PR DESCRIPTION
I had a corrupted mod_pbxproj.pyc file so none of the Soomla runners were actually running during an iOS build. The console didn't indicate any errors and as there are numerous console output lines in my build (due to other plugins) I didn't' realize there was an error with the Soomla post process.

This patch changes the error report from a regular Debug.Log to a Debug.ErrorLog so errors are highlighted.