### PR TITLE
Removed USEFLOAT flag to default JSONObject to doubles instead of floats. 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/soomla/soomla-ios-core
 [submodule "submodules/soomla-android-core"]
 	path = submodules/soomla-android-core
-	url = git@github.com:soomla/soomla-android-core.git
+	url = https://github.com/soomla/soomla-android-core.git

--- a/Soomla/Assets/Plugins/Soomla/Core/JSONObject.cs
+++ b/Soomla/Assets/Plugins/Soomla/Core/JSONObject.cs
@@ -1,6 +1,6 @@
 #define PRETTY		//Comment out when you no longer need to read JSON to disable pretty Print system-wide
-//Using doubles will cause errors in VectorTemplates.cs; Unity speaks floats
-#define USEFLOAT	//Use floats for numbers instead of doubles	(enable if you're getting too many significant digits in string output)
+//Using doubles will cause errors in VectorTemplates.cs; Unity speaks floats, though floats will only provide you 7 digits of precision when updating Soomla StoreInventory balances
+//#define USEFLOAT	//Use floats for numbers instead of doubles	(enable if you're getting too many significant digits in string output)
 //#define POOLING	//Currently using a build setting for this one (also it's experimental)
 
 using System.Diagnostics;

--- a/Soomla/Assets/Plugins/Soomla/Core/JSONObject.cs
+++ b/Soomla/Assets/Plugins/Soomla/Core/JSONObject.cs
@@ -364,9 +364,9 @@ public class JSONObject : NullCheckable {
 					default:
 						try {
 							#if USEFLOAT
-							n = System.Convert.ToSingle(str);
+							n = System.Single.Parse(str);
 							#else
-							n = System.Convert.ToDouble(str);				 
+							n = System.Double.Parse(str);				 
 							#endif
 							type = Type.NUMBER;
 						} catch(System.FormatException) {
@@ -738,7 +738,7 @@ public class JSONObject : NullCheckable {
 					builder.Append(NaN);
 				#endif
 				else
-					builder.Append(n.ToString());
+					builder.Append(n.ToString("r"));
 				break;
 			case Type.OBJECT:
 				builder.Append("{");
@@ -870,7 +870,7 @@ public class JSONObject : NullCheckable {
 					builder.Append(NaN);
 				#endif
 				else
-					builder.Append(n.ToString());
+					builder.Append(n.ToString("r"));
 				break;
 			case Type.OBJECT:
 				builder.Append("{");


### PR DESCRIPTION
Cloning the `soomla-android-core` submodule failed with the previous URL.