### PR TITLE
Removed JSONObject USEFLOAT flag to default to doubles instead of floats

### DIFF
--- a/Soomla/Assets/Plugins/Soomla/Core/JSONObject.cs
+++ b/Soomla/Assets/Plugins/Soomla/Core/JSONObject.cs
@@ -1,6 +1,6 @@
 #define PRETTY		//Comment out when you no longer need to read JSON to disable pretty Print system-wide
-//Using doubles will cause errors in VectorTemplates.cs; Unity speaks floats
-#define USEFLOAT	//Use floats for numbers instead of doubles	(enable if you're getting too many significant digits in string output)
+//Using doubles will cause errors in VectorTemplates.cs; Unity speaks floats, though floats will only provide you 7 digits of precision when updating Soomla StoreInventory balances
+//#define USEFLOAT	//Use floats for numbers instead of doubles	(enable if you're getting too many significant digits in string output)
 //#define POOLING	//Currently using a build setting for this one (also it's experimental)
 
 using System.Diagnostics;


### PR DESCRIPTION
Using floats only provides 7 digits of precision when updating Soomla StoreInventory balances. Changing to doubles provides 15 digits of precision with the default format string.