### PR TITLE
Removes FileNotFound exception in Unity 5.3

### DIFF
--- a/Soomla/Assets/Plugins/Soomla/Core/Config/android/SoomlaManifestTools.cs
+++ b/Soomla/Assets/Plugins/Soomla/Core/Config/android/SoomlaManifestTools.cs
@@ -21,7 +21,7 @@ namespace Soomla
 		{
 #if UNITY_4_5 || UNITY_4_6 || UNITY_5_0 || UNITY_5_1
 		var inputFile = Path.Combine(EditorApplication.applicationContentsPath, "PlaybackEngines/androidplayer/AndroidManifest.xml");
-#elif UNITY_5_2
+#elif UNITY_5_2 || UNITY_5_3
 		var inputFile = Path.Combine(EditorApplication.applicationContentsPath, "PlaybackEngines/androidplayer/Apk/AndroidManifest.xml");
 #else				
 		var inputFile = Path.Combine(EditorApplication.applicationPath, "../PlaybackEngines/androidplayer/Apk/AndroidManifest.xml");


### PR DESCRIPTION
When a brand new project is open in Unity5.3 the missing #elif for that version defaulted to the catch-all #else and a FileNotFound exception was raised.

I've tested adding the UNITY_5_3 define side by side to the UNITY_5_2 one and it worked.